### PR TITLE
log: Add Xbox debugPrint()

### DIFF
--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -24,6 +24,10 @@
 #include "core/windows/SDL_windows.h"
 #endif
 
+#if defined(__XBOX__)
+#include <hal/debug.h>
+#endif
+
 /* Simple log messages in SDL */
 
 #include "SDL_error.h"
@@ -392,6 +396,10 @@ SDL_LogOutput(void *userdata, int category, SDL_LogPriority priority,
 
         SDL_free(tstr);
         SDL_small_free(output, isstack);
+    }
+#elif defined(__XBOX__)
+    {
+        debugPrint("%s: %s\n", SDL_priority_prefixes[priority], message);
     }
 #elif defined(__ANDROID__)
     {


### PR DESCRIPTION
I decided against upstreaming as `SDL_Log` would then break some games (in XQEMU primarily) or render unwanted messages. The `SDL_Log` interface doesn't look too suitable for rendering to the display, and the PSP interface also doesn't do it (despite having similar APIs).

The code can still be used as reference for adding another debug backend (`OutputDebugString` maybe?)